### PR TITLE
Delete website and telegram group

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 
 XGFW is your very own DIY Great Firewall of China (https://en.wikipedia.org/wiki/Great_Firewall), available as a flexible, easy-to-use open source program on Linux. Why let the powers that be have all the fun? It's time to give power to the people and democratize censorship. Bring the thrill of cyber-sovereignty right into your home router and start filtering like a pro - you too can play Big Brother.
 
-**Documentation site: https://gfw.dev/**
-
-Telegram group: https://t.me/NextGFW
-
 > [!CAUTION]
 > This project is still in very early stages of development. Use at your own risk. We are looking for contributors to help us improve and expand the project.
 


### PR DESCRIPTION
如题，文档网站不被开发者所控制，而tg群组早已废弃。